### PR TITLE
Fix language selection bug

### DIFF
--- a/quicktry/templates/index.html
+++ b/quicktry/templates/index.html
@@ -7,7 +7,7 @@
     <input id="code" name="code" type="text" style="width:500px; height: 300px;"/><br>
     <select name="language" id="language"><br> 
     {% for o in option_list %}
-       <option name = "{{o}}"> {{o}} </option>
+       <option name = "{{o}}">{{o}}</option>
        {% endfor %}
     </select>
     <strong><div id="echoResult"></div></strong>

--- a/quicktry/views.py
+++ b/quicktry/views.py
@@ -1,19 +1,12 @@
 from quicktry import app, sandbox
 from flask import jsonify, request, render_template
 import os
-import yaml
+
 
 @app.route('/')
 def index():
-    unedited_list = sandbox.query_images()
-    option_list=[]
-    for val in unedited_list:
-        first = val.index('-')+1
-        end = val.index(':')
-        val=val[first:end]
-        option_list.append(val)
-
-    return render_template('index.html', option_list=option_list)
+    options = sandbox.get_languages()
+    return render_template('index.html', option_list=options)
 
 
 @app.route('/run', methods=['GET', 'POST'])


### PR DESCRIPTION
This fixes immediate bugs from pr #8. 

The list of languages was unavailable when loading the demo page. This replaces
parsing of the available image names and uses get_languages() instead. There
were also issues with selecting text from the dropdown; the text was padded
with spaces. 
